### PR TITLE
Update app() to reflect correct name

### DIFF
--- a/src/Http/Controllers/Discord/DiscordOAuthController.php
+++ b/src/Http/Controllers/Discord/DiscordOAuthController.php
@@ -177,7 +177,7 @@ class DiscordOAuthController
      */
     private function getDmChannel(User $user)
     {
-        return app('discord')
+        return app('seatnotifications-discord')
             ->user
             ->createDm([
                 'recipient_id' => $user->id,


### PR DESCRIPTION
this is a leftover from the rename of all the apps to avoid interdependencies with warlofs packages